### PR TITLE
CP-1895 Created action to release on tag.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         run: |
           echo "New version: ${GITHUB_REF_NAME}"
           echo "Github username: ${GITHUB_ACTOR}"

--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,12 @@ allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'maven-publish'
     apply plugin: 'java-library'
+    apply plugin: 'signing'
+    apply plugin: 'jacoco'
     group = 'com.thousandeyes.sdk'
 }
 
 subprojects {
-    apply plugin: 'jacoco'
-
-
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 
@@ -122,6 +121,14 @@ subprojects {
                 }
             }
         }
+    }
+
+    signing {
+        def signingKeyId = findProperty("signingKeyId")
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        sign publishing.publications.mavenJava
     }
 }
 


### PR DESCRIPTION
Tested a slightly different approach in my fork, uploading the packages to [Github Packages](https://docs.gradle.org/current/userguide/signing_plugin.html#signing_plugin). The end result can be seen [here](https://github.com/joaomper-TE?tab=packages&repo_name=thousandeyes-sdk-java):

![image](https://github.com/user-attachments/assets/de8d48a5-bb51-4251-a653-893dae441457)



Still missing:
- Credentials from Cisco on Maven
- Checking with Cisco if we need to sign the packages - https://docs.gradle.org/current/userguide/signing_plugin.html#signing_plugin