### PR TITLE
CP-1895 Replace publishing plugin.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,12 @@ jobs:
           java-version: '17'
       - name: Publish artifact
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         run: |
           echo "New version: ${GITHUB_REF_NAME}"
           echo "Github username: ${GITHUB_ACTOR}"
-          gradle -Pversion=${GITHUB_REF_NAME} publish --parallel
+          gradle -Pversion=${GITHUB_REF_NAME} publishMavenPublicationToMavenCentralRepository --parallel

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,13 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 buildscript {
     repositories {
         mavenCentral()
     }
+}
+
+plugins {
+    id "com.vanniktech.maven.publish" version "0.29.0"
 }
 
 ext {
@@ -17,10 +23,9 @@ ext {
 allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
-    apply plugin: 'maven-publish'
     apply plugin: 'java-library'
-    apply plugin: 'signing'
     apply plugin: 'jacoco'
+    apply plugin: 'com.vanniktech.maven.publish'
     group = 'com.thousandeyes.sdk'
 }
 
@@ -31,9 +36,7 @@ subprojects {
     // Some text from the schema is copy pasted into the source files as UTF-8
     // but the default still seems to be to use platform encoding
     tasks.withType(JavaCompile) {
-        configure(options) {
-            options.encoding = 'UTF-8'
-        }
+        options.encoding = 'UTF-8'
     }
     javadoc {
         options.encoding = 'UTF-8'
@@ -41,11 +44,6 @@ subprojects {
 
     task execute(type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
-    }
-
-    java {
-        withJavadocJar()
-        withSourcesJar()
     }
 
     def jacocoXmlReport = "${project.rootDir}/${project.name}/reports/jacoco/${project.name}.xml"
@@ -67,68 +65,39 @@ subprojects {
 
     test {
         useJUnitPlatform()
-        ignoreFailures true
+        ignoreFailures = true
         finalizedBy jacocoTestReport
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
 
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                artifactId = project.name
-                from components.java
-                versionMapping {
-                    usage('java-api') {
-                        fromResolutionOf('runtimeClasspath')
-                    }
-                    usage('java-runtime') {
-                        fromResolutionResult()
-                    }
-                }
-                pom {
-                    name = 'ThousandEyes Java SDK - ${project.name}'
-                    description = 'A set of Java client libraries for the [Thousandeyes v7 API](https://developer.cisco.com/docs/thousandeyes/v7/).'
-                    url = 'https://github.com/thousandeyes/thousandeyes-sdk-java'
-                    licenses {
-                        license {
-                            name = 'The Apache License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
-                    developers {
-                        developer {
-                            name = 'ThousandEyes API Team'
-                            email = 'api-team@thousandeyes.com'
-                            organization = 'Cisco - ThousandEyes'
-                            organizationUrl = 'https://www.thousandeyes.com'
-                        }
-                    }
-                    scm {
-                        connection = 'scm:git:git://github.com/thousandeyes/thousandeyes-sdk-java.git'
-                        developerConnection = 'scm:git:ssh://github.com/thousandeyes/thousandeyes-sdk-java.git'
-                        url = 'https://github.com/thousandeyes/thousandeyes-sdk-java/tree/main'
-                    }
+    mavenPublishing {
+        coordinates("com.thousandeyes.sdk", project.name, null)
+        pom {
+            name = 'ThousandEyes Java SDK - ${project.name}'
+            description = 'A set of Java client libraries for the [Thousandeyes v7 API](https://developer.cisco.com/docs/thousandeyes/v7/).'
+            url = 'https://github.com/thousandeyes/thousandeyes-sdk-java'
+            licenses {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                 }
             }
-        }
-        repositories {
-            maven {
-                name = "CentralPortal"
-                url = "https://central.sonatype.com/api/v1/publisher"
-                credentials {
-                    username = System.getenv("MAVEN_USERNAME")
-                    password = System.getenv("MAVEN_PASSWORD")
+            developers {
+                developer {
+                    name = 'ThousandEyes API Team'
+                    email = 'api-team@thousandeyes.com'
+                    organization = 'Cisco - ThousandEyes'
+                    organizationUrl = 'https://www.thousandeyes.com'
                 }
             }
+            scm {
+                connection = 'scm:git:git://github.com/thousandeyes/thousandeyes-sdk-java.git'
+                developerConnection = 'scm:git:ssh://github.com/thousandeyes/thousandeyes-sdk-java.git'
+                url = 'https://github.com/thousandeyes/thousandeyes-sdk-java/tree/main'
+            }
         }
-    }
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
-    signing {
-        def signingKeyId = findProperty("signingKeyId")
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-        sign publishing.publications.mavenJava
+        signAllPublications()
     }
 }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Essentially SonaType changed the default place where to put the artifact recently, Central Portal vs OSSRH.

To publish to the 1st, we have to use a different plugin - if we use Jreleaser that they recommend [here](https://central.sonatype.org/publish/publish-portal-gradle/) we have problems due to the subprojects - https://github.com/jreleaser/jreleaser/discussions/1237.

Ended up using https://github.com/vanniktech/gradle-maven-publish-plugin/?tab=readme-ov-file which is also suggested in that page, and has some stars.