### PR TITLE
bug: fix pom files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ subprojects {
     mavenPublishing {
         coordinates("com.thousandeyes.sdk", project.name, project.version)
         pom {
-            name = 'ThousandEyes Java SDK - ${project.name}'
-            description = 'A set of Java client libraries for the [Thousandeyes v7 API](https://developer.cisco.com/docs/thousandeyes/v7/).'
+            name = "ThousandEyes Java SDK - ${project.name}"
+            description = 'A set of Java client libraries for the Thousandeyes v7 API. For more information, visit: https://developer.cisco.com/docs/thousandeyes/v7/'
             url = 'https://github.com/thousandeyes/thousandeyes-sdk-java'
             licenses {
                 license {


### PR DESCRIPTION
While creating a Maven project, I ran into this error:
```
The POM for com.thousandeyes.sdk:client:jar:1.0.0 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
```

which came from 
`[ERROR] Resolving expression: '${project.name}': Detected the following recursive expression cycle in 'project.name': [name] @ `

Because of this, transitive dependencies are not being imported automatically and what works in Gradle does not work in Maven.