### PR TITLE
CP-2300 Publish release automatically after Validated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects {
                 url = 'https://github.com/thousandeyes/thousandeyes-sdk-java/tree/main'
             }
         }
-        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
 
         signAllPublications()
     }


### PR DESCRIPTION
I think I found an alternative way of doing this, instead of using the [Publisher API](https://central.sonatype.org/publish/publish-portal-api/#uploading-a-deployment-bundle) (and requesting a Bearer token from Cisco).

The [plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#automatic-release) that we are using for publishing allows to automatically release - same as what we would be doing with the Publisher API i.e. setting `publishingType` to `AUTOMATIC` - after the release is correctly Validated. Trying this approach first.

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/c38593e2-a195-499d-b4c9-6ccce844bcd2">
