### PR TITLE
feature: remove `sendForList` method and use `Type` class instead

### DIFF
--- a/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/AccountGroupsApi.java
+++ b/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/AccountGroupsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.account.management.administrative.model.AccountGroupDetail;
 import com.thousandeyes.sdk.account.management.administrative.model.AccountGroupRequest;
 import com.thousandeyes.sdk.account.management.administrative.model.AccountGroups;

--- a/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/PermissionsApi.java
+++ b/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/PermissionsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.account.management.administrative.model.Error;
 import com.thousandeyes.sdk.account.management.administrative.model.Permissions;
 import com.thousandeyes.sdk.account.management.administrative.model.UnauthorizedError;

--- a/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/RolesApi.java
+++ b/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/RolesApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.account.management.administrative.model.Error;
 import com.thousandeyes.sdk.account.management.administrative.model.RoleDetail;
 import com.thousandeyes.sdk.account.management.administrative.model.RoleRequestBody;

--- a/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/UserEventsApi.java
+++ b/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/UserEventsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.account.management.administrative.model.AuditUserEvents;
 import com.thousandeyes.sdk.account.management.administrative.model.Error;
 import java.time.OffsetDateTime;

--- a/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/UsersApi.java
+++ b/administrative/src/main/java/com/thousandeyes/sdk/account/management/administrative/UsersApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.account.management.administrative.model.CreatedUser;
 import com.thousandeyes.sdk.account.management.administrative.model.Error;
 import java.net.URI;

--- a/agents/src/main/java/com/thousandeyes/sdk/agents/AgentProxiesApi.java
+++ b/agents/src/main/java/com/thousandeyes/sdk/agents/AgentProxiesApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.agents.model.AgentProxies;
 import com.thousandeyes.sdk.agents.model.Error;
 import com.thousandeyes.sdk.agents.model.UnauthorizedError;

--- a/agents/src/main/java/com/thousandeyes/sdk/agents/CloudAndEnterpriseAgentNotificationRulesApi.java
+++ b/agents/src/main/java/com/thousandeyes/sdk/agents/CloudAndEnterpriseAgentNotificationRulesApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.agents.model.Error;
 import com.thousandeyes.sdk.agents.model.ListNotificationRulesResponse;
 import com.thousandeyes.sdk.agents.model.NotificationRuleDetail;

--- a/agents/src/main/java/com/thousandeyes/sdk/agents/CloudAndEnterpriseAgentsApi.java
+++ b/agents/src/main/java/com/thousandeyes/sdk/agents/CloudAndEnterpriseAgentsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.agents.model.AgentDetails;
 import com.thousandeyes.sdk.agents.model.AgentDetailsExpand;
 import com.thousandeyes.sdk.agents.model.AgentListExpand;

--- a/agents/src/main/java/com/thousandeyes/sdk/agents/EnterpriseAgentClusterApi.java
+++ b/agents/src/main/java/com/thousandeyes/sdk/agents/EnterpriseAgentClusterApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.agents.model.AgentClusterAssignRequest;
 import com.thousandeyes.sdk.agents.model.AgentClusterUnassignRequest;
 import com.thousandeyes.sdk.agents.model.AgentDetails;

--- a/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertRulesApi.java
+++ b/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertRulesApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.alerts.model.Error;
 import com.thousandeyes.sdk.alerts.model.Rule;
 import com.thousandeyes.sdk.alerts.model.RuleDetail;

--- a/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertSuppressionWindowsApi.java
+++ b/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertSuppressionWindowsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.alerts.model.AlertSuppressionWindowDetail;
 import com.thousandeyes.sdk.alerts.model.AlertSuppressionWindowRequest;
 import com.thousandeyes.sdk.alerts.model.AlertSuppressionWindows;

--- a/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertsApi.java
+++ b/alerts/src/main/java/com/thousandeyes/sdk/alerts/AlertsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.alerts.model.AlertDetail;
 import com.thousandeyes.sdk.alerts.model.Alerts;
 import com.thousandeyes.sdk.alerts.model.Error;

--- a/bgp-monitors/src/main/java/com/thousandeyes/sdk/bgp/monitors/BgpMonitorsApi.java
+++ b/bgp-monitors/src/main/java/com/thousandeyes/sdk/bgp/monitors/BgpMonitorsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.bgp.monitors.model.Error;
 import com.thousandeyes.sdk.bgp.monitors.model.Monitors;
 import com.thousandeyes.sdk.bgp.monitors.model.UnauthorizedError;

--- a/core/client-native/src/main/java/com/thousandeyes/sdk/client/NativeApiClient.java
+++ b/core/client-native/src/main/java/com/thousandeyes/sdk/client/NativeApiClient.java
@@ -20,11 +20,11 @@ package com.thousandeyes.sdk.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
 
@@ -50,19 +50,10 @@ public class NativeApiClient implements ApiClient {
     }
 
     @Override
-    public <T> ApiResponse<T> send(ApiRequest request, Class<T> returnType) throws ApiException {
+    public <T> ApiResponse<T> send(ApiRequest request, Type returnType) throws ApiException {
         return sendRequestAndProcessResponse(
                 getRequestBuilder(request),
-                mapper.readerFor(returnType));
-    }
-
-    @Override
-    public <T> ApiResponse<List<T>> sendForList(ApiRequest request, Class<T> returnType)
-            throws ApiException
-    {
-        return sendRequestAndProcessResponse(
-                getRequestBuilder(request),
-                mapper.readerForListOf(returnType));
+                mapper.readerFor(mapper.constructType(returnType)));
     }
 
     private HttpRequest.Builder getRequestBuilder(ApiRequest request) throws ApiException {

--- a/core/client-native/src/test/java/com/thousandeyes/sdk/client/NativeApiClientTest.java
+++ b/core/client-native/src/test/java/com/thousandeyes/sdk/client/NativeApiClientTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.reflect.TypeUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,7 +115,7 @@ class NativeApiClientTest {
         var expectedResponse = List.of(new Response("name", OffsetDateTime.now(ZoneId.of("UTC"))));
         stubHttpClient(expectedResponse);
 
-        var response = apiClient.sendForList(request, Response.class);
+        var response = apiClient.send(request, TypeUtils.parameterize(List.class, Response.class));
 
         assertEquals(expectedResponse, response.getData());
     }

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/ApiClient.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/ApiClient.java
@@ -18,13 +18,10 @@
 
 package com.thousandeyes.sdk.client;
 
-import java.util.List;
+import java.lang.reflect.Type;
 
 
 
 public interface ApiClient {
-    <T> ApiResponse<T> send(ApiRequest request, Class<T> returnType) throws ApiException;
-
-    <T> ApiResponse<List<T>> sendForList(ApiRequest request, Class<T> returnType)
-            throws ApiException;
+    <T> ApiResponse<T> send(ApiRequest request, Type returnType) throws ApiException;
 }

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/ApiClientDecorator.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/ApiClientDecorator.java
@@ -18,7 +18,7 @@
 
 package com.thousandeyes.sdk.client;
 
-import java.util.List;
+import java.lang.reflect.Type;
 import java.util.concurrent.Callable;
 
 import lombok.RequiredArgsConstructor;
@@ -30,17 +30,10 @@ public abstract class ApiClientDecorator implements ApiClient {
     private final ApiClient apiClient;
 
     @Override
-    public final <T> ApiResponse<T> send(ApiRequest request, Class<T> returnType)
+    public final <T> ApiResponse<T> send(ApiRequest request, Type returnType)
             throws ApiException
     {
         return decorate(() -> apiClient.send(request, returnType));
-    }
-
-    @Override
-    public final <T> ApiResponse<List<T>> sendForList(ApiRequest request, Class<T> returnType)
-            throws ApiException
-    {
-        return decorate(() -> apiClient.sendForList(request, returnType));
     }
 
     public abstract <T> ApiResponse<T> decorate(Callable<ApiResponse<T>> requestCallable)

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/ApiException.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/ApiException.java
@@ -18,7 +18,7 @@
 
 package com.thousandeyes.sdk.client;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 import lombok.Getter;
@@ -28,10 +28,11 @@ import lombok.Getter;
 @Getter
 public class ApiException extends Exception {
     private int code = 0;
-    private Map<String, List<String>> responseHeaders = null;
+    private Map<String, ? extends Collection<String>> responseHeaders = null;
     private Object responseBody = null;
 
-    public ApiException() {}
+    public ApiException() {
+    }
 
     public ApiException(Throwable throwable) {
         super(throwable);
@@ -41,22 +42,32 @@ public class ApiException extends Exception {
         super(message);
     }
 
-    public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, Object responseBody) {
+    public ApiException(String message, Throwable throwable, int code,
+                        Map<String, ? extends Collection<String>> responseHeaders,
+                        Object responseBody)
+    {
         super(message, throwable);
         this.code = code;
         this.responseHeaders = responseHeaders;
         this.responseBody = responseBody;
     }
 
-    public ApiException(String message, int code, Map<String, List<String>> responseHeaders, Object responseBody) {
+    public ApiException(String message, int code,
+                        Map<String, ? extends Collection<String>> responseHeaders,
+                        Object responseBody)
+    {
         this(message, null, code, responseHeaders, responseBody);
     }
 
-    public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
+    public ApiException(String message, Throwable throwable, int code,
+                        Map<String, ? extends Collection<String>> responseHeaders)
+    {
         this(message, throwable, code, responseHeaders, null);
     }
 
-    public ApiException(int code, Map<String, List<String>> responseHeaders, Object responseBody) {
+    public ApiException(int code, Map<String, ? extends Collection<String>> responseHeaders,
+                        Object responseBody)
+    {
         this(null, null, code, responseHeaders, responseBody);
     }
 
@@ -65,7 +76,10 @@ public class ApiException extends Exception {
         this.code = code;
     }
 
-    public ApiException(int code, String message, Map<String, List<String>> responseHeaders, Object responseBody) {
+    public ApiException(int code, String message,
+                        Map<String, ? extends Collection<String>> responseHeaders,
+                        Object responseBody)
+    {
         this(code, message);
         this.responseHeaders = responseHeaders;
         this.responseBody = responseBody;

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/ApiRequest.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/ApiRequest.java
@@ -19,6 +19,7 @@
 package com.thousandeyes.sdk.client;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,6 @@ public class ApiRequest {
     Object requestBody;
     List<Pair<String, String>> queryParams;
     @Singular
-    Map<String, List<String>> headers;
+    Map<String, ? extends Collection<String>> headers;
     Duration readTimeout;
 }

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/ApiResponse.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/ApiResponse.java
@@ -18,21 +18,24 @@
 
 package com.thousandeyes.sdk.client;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 import lombok.Getter;
 
+
+
 @Getter
 public class ApiResponse<T> {
     final private int statusCode;
-    final private Map<String, List<String>> headers;
+    final private Map<String, ? extends Collection<String>> headers;
     final private T data;
-    
-    public ApiResponse(int statusCode, Map<String, List<String>> headers) {
+
+    public ApiResponse(int statusCode, Map<String, ? extends Collection<String>> headers) {
         this(statusCode, headers, null);
     }
-    public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
+
+    public ApiResponse(int statusCode, Map<String, ? extends Collection<String>> headers, T data) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.data = data;

--- a/core/client/src/main/java/com/thousandeyes/sdk/client/RateLimitDecorator.java
+++ b/core/client/src/main/java/com/thousandeyes/sdk/client/RateLimitDecorator.java
@@ -19,8 +19,10 @@
 package com.thousandeyes.sdk.client;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -60,11 +62,11 @@ public final class RateLimitDecorator extends ApiClientDecorator {
         throw apiException;
     }
 
-    private OptionalLong retryAfterInSeconds(Map<String, List<String>> headers) {
+    private OptionalLong retryAfterInSeconds(Map<String, ? extends Collection<String>> headers) {
         return RATE_LIMIT_RESET_HEADERS.stream()
-                                       .flatMap(headerName -> headers.getOrDefault(headerName,
-                                                                                   List.of())
-                                                                     .stream())
+                                       .flatMap(headerName -> Optional.ofNullable(
+                                               headers.get(headerName)).stream())
+                                       .flatMap(Collection::stream)
                                        .mapToLong(Long::parseLong)
                                        .map(rlResetInstant -> rlResetInstant -
                                                               Instant.now().getEpochSecond())

--- a/core/client/src/test/java/com/thousandeyes/sdk/RateLimitDecoratorTest.java
+++ b/core/client/src/test/java/com/thousandeyes/sdk/RateLimitDecoratorTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class RateLimitDecoratorTest {
 
     @Test
     void shouldNotAwaitOtherStatusCode() throws ApiException {
-        when(client.send(any(), eq(String.class))).thenReturn(okResponse);
+        when(client.<String>send(any(), eq(String.class))).thenReturn(okResponse);
         var response = rlClient.send(mock(ApiRequest.class), String.class);
         assertEquals(response, okResponse);
     }
@@ -80,12 +81,12 @@ public class RateLimitDecoratorTest {
     @ValueSource(strings = { "x-organization-rate-limit-reset", "x-instant-test-rate-limit-reset" })
     void shouldRetryProperRateLimitApiException(String header) throws ApiException {
         var resetTime = getTimeInSeconds(Instant.now().plusSeconds(2));
-        var headers = Map.of(header, List.of(resetTime));
+        Map<String, Collection<String>> headers = Map.of(header, List.of(resetTime));
 
         var exception = new ApiException(TOO_MANY_REQUESTS, headers, null);
 
-        when(client.send(any(), eq(String.class))).thenThrow(exception)
-                                                  .thenReturn(okResponse);
+        when(client.<String>send(any(), eq(String.class))).thenThrow(exception)
+                                                          .thenReturn(okResponse);
 
         var response = rlClient.send(mock(ApiRequest.class), String.class);
         assertEquals(response, okResponse);

--- a/credentials/src/main/java/com/thousandeyes/sdk/credentials/CredentialsApi.java
+++ b/credentials/src/main/java/com/thousandeyes/sdk/credentials/CredentialsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.credentials.model.Credential;
 import com.thousandeyes.sdk.credentials.model.CredentialRequest;
 import com.thousandeyes.sdk.credentials.model.CredentialWithoutValue;

--- a/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardSnapshotsApi.java
+++ b/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardSnapshotsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.dashboards.model.ApiDashboardSnapshot;
 import com.thousandeyes.sdk.dashboards.model.ApiWidgetDataSnapshotResponse;
 import com.thousandeyes.sdk.dashboards.model.DashboardSnapshotResponse;

--- a/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardsApi.java
+++ b/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.dashboards.model.ApiDashboard;
 import com.thousandeyes.sdk.dashboards.model.ApiWidgetDataResponse;
 import java.math.BigDecimal;
@@ -336,7 +336,7 @@ public class DashboardsApi {
 
     var requestBuilder = getDashboardsRequestBuilder(aid);
 
-    return apiClient.sendForList(requestBuilder.build(), ApiDashboard.class);
+    return apiClient.send(requestBuilder.build(), TypeUtils.parameterize(List.class, ApiDashboard.class));
   }
 
   private void getDashboardsValidateRequest() throws ApiException {

--- a/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardsFiltersApi.java
+++ b/dashboards/src/main/java/com/thousandeyes/sdk/dashboards/DashboardsFiltersApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.dashboards.model.ApiContextFilterRequest;
 import com.thousandeyes.sdk.dashboards.model.ApiContextFilterResponse;
 import com.thousandeyes.sdk.dashboards.model.ApiContextFiltersResponse;

--- a/emulation/src/main/java/com/thousandeyes/sdk/emulation/EmulationApi.java
+++ b/emulation/src/main/java/com/thousandeyes/sdk/emulation/EmulationApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.emulation.model.EmulatedDevice;
 import com.thousandeyes.sdk.emulation.model.EmulatedDeviceResponse;
 import com.thousandeyes.sdk.emulation.model.EmulatedDeviceResponses;

--- a/endpoint-agents/src/main/java/com/thousandeyes/sdk/endpoint/agents/EndpointAgentsApi.java
+++ b/endpoint-agents/src/main/java/com/thousandeyes/sdk/endpoint/agents/EndpointAgentsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.agents.model.AgentSearchRequest;
 import com.thousandeyes.sdk.endpoint.agents.model.ConnectionString;
 import com.thousandeyes.sdk.endpoint.agents.model.EndpointAgent;

--- a/endpoint-agents/src/main/java/com/thousandeyes/sdk/endpoint/agents/EndpointAgentsTransferApi.java
+++ b/endpoint-agents/src/main/java/com/thousandeyes/sdk/endpoint/agents/EndpointAgentsTransferApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.agents.model.AgentTransferRequest;
 import com.thousandeyes.sdk.endpoint.agents.model.BulkAgentTransferRequest;
 import com.thousandeyes.sdk.endpoint.agents.model.BulkAgentTransferResponse;

--- a/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/AgentToServerEndpointInstantScheduledTestsApi.java
+++ b/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/AgentToServerEndpointInstantScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.EndpointAgentToServerInstantTest;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.EndpointAgentToServerTest;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.Error;

--- a/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/HttpServerEndpointInstantScheduledTestsApi.java
+++ b/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/HttpServerEndpointInstantScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.EndpointHttpServerInstantTest;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.EndpointHttpServerTest;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.Error;

--- a/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/RunEndpointInstantScheduledTestsApi.java
+++ b/endpoint-instant-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/instant/RunEndpointInstantScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.EndpointRunScheduledInstantTestResult;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.instant.model.UnauthorizedError;

--- a/endpoint-labels/src/main/java/com/thousandeyes/sdk/endpoint/labels/EndpointAgentLabelsApi.java
+++ b/endpoint-labels/src/main/java/com/thousandeyes/sdk/endpoint/labels/EndpointAgentLabelsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.labels.model.Error;
 import com.thousandeyes.sdk.endpoint.labels.model.ExpandLabelOptions;
 import com.thousandeyes.sdk.endpoint.labels.model.Label;

--- a/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/HttpServerEndpointScheduledTestResultsApi.java
+++ b/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/HttpServerEndpointScheduledTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.results.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.results.model.ExpandEndpointHttpServerOptions;
 import com.thousandeyes.sdk.endpoint.tests.results.model.HttpEndpointTestResults;

--- a/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/LocalNetworkEndpointTestResultsApi.java
+++ b/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/LocalNetworkEndpointTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.results.model.EndpointNetworkTopologyResultRequest;
 import com.thousandeyes.sdk.endpoint.tests.results.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.results.model.LocalNetworkResults;

--- a/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/NetworkDynamicEndpointTestResultsApi.java
+++ b/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/NetworkDynamicEndpointTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.results.model.DynamicEndpointTestsDataRoundSearch;
 import com.thousandeyes.sdk.endpoint.tests.results.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.results.model.NetworkDynamicEndpointTestResults;

--- a/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/NetworkEndpointScheduledTestResultsApi.java
+++ b/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/NetworkEndpointScheduledTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.results.model.EndpointTestsDataRoundsSearch;
 import com.thousandeyes.sdk.endpoint.tests.results.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.results.model.MultiTestIdEndpointTestsDataRoundsSearch;

--- a/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/RealUserEndpointTestResultsApi.java
+++ b/endpoint-test-results/src/main/java/com/thousandeyes/sdk/endpoint/tests/results/RealUserEndpointTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.results.model.Error;
 import java.time.OffsetDateTime;
 import com.thousandeyes.sdk.endpoint.tests.results.model.RealUserEndpointTestDetailResults;

--- a/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/AgentToServerEndpointDynamicTestsApi.java
+++ b/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/AgentToServerEndpointDynamicTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.model.DynamicTest;
 import com.thousandeyes.sdk.endpoint.tests.model.DynamicTestRequest;
 import com.thousandeyes.sdk.endpoint.tests.model.DynamicTests;

--- a/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/AgentToServerEndpointScheduledTestsApi.java
+++ b/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/AgentToServerEndpointScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointAgentToServerTest;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointAgentToServerTestRequest;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointAgentToServerTests;

--- a/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/EndpointScheduledTestsApi.java
+++ b/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/EndpointScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointTests;
 import com.thousandeyes.sdk.endpoint.tests.model.Error;
 import com.thousandeyes.sdk.endpoint.tests.model.UnauthorizedError;

--- a/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/HttpServerEndpointScheduledTestsApi.java
+++ b/endpoint-tests/src/main/java/com/thousandeyes/sdk/endpoint/tests/HttpServerEndpointScheduledTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointHttpServerTest;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointHttpServerTestRequest;
 import com.thousandeyes.sdk.endpoint.tests.model.EndpointHttpServerTests;

--- a/event-detection/src/main/java/com/thousandeyes/sdk/event/detection/EventsApi.java
+++ b/event-detection/src/main/java/com/thousandeyes/sdk/event/detection/EventsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.event.detection.model.Error;
 import com.thousandeyes.sdk.event.detection.model.EventDetail;
 import com.thousandeyes.sdk.event.detection.model.Events;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/AgentToAgentInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/AgentToAgentInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.AgentToAgentInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.AgentToAgentInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/AgentToServerInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/AgentToServerInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.AgentToServerInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.AgentToServerInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/ApiInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/ApiInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.ApiInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.ApiInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnsServerInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnsServerInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.DnsServerInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.DnsServerInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnsTraceInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnsTraceInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.DnsTraceInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.DnsTraceInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnssecInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/DnssecInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.DnsSecInstantTestRequest;
 import com.thousandeyes.sdk.tests.instant.model.DnsSecInstantTestResponse;
 import com.thousandeyes.sdk.tests.instant.model.Error;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/FtpServerInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/FtpServerInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import com.thousandeyes.sdk.tests.instant.model.FtpServerInstantTestRequest;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/HttpPageLoadInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/HttpPageLoadInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import com.thousandeyes.sdk.tests.instant.model.PageLoadInstantTestRequest;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/HttpServerInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/HttpServerInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import com.thousandeyes.sdk.tests.instant.model.HttpServerInstantTestRequest;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/InstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/InstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.UnauthorizedError;
 

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/SipServerInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/SipServerInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import com.thousandeyes.sdk.tests.instant.model.SipServerInstantTestRequest;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/VoiceInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/VoiceInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import java.net.URI;

--- a/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/WebTransactionInstantTestsApi.java
+++ b/instant-tests/src/main/java/com/thousandeyes/sdk/tests/instant/WebTransactionInstantTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.instant.model.Error;
 import com.thousandeyes.sdk.tests.instant.model.ExpandInstantTestOptions;
 import java.net.URI;

--- a/internet-insights/src/main/java/com/thousandeyes/sdk/internet/insights/InternetInsightsCatalogProvidersApi.java
+++ b/internet-insights/src/main/java/com/thousandeyes/sdk/internet/insights/InternetInsightsCatalogProvidersApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.internet.insights.model.ApiCatalogProviderDetails;
 import com.thousandeyes.sdk.internet.insights.model.ApiCatalogProviderFilter;
 import com.thousandeyes.sdk.internet.insights.model.ApiCatalogProviderResponse;

--- a/internet-insights/src/main/java/com/thousandeyes/sdk/internet/insights/InternetInsightsOutagesApi.java
+++ b/internet-insights/src/main/java/com/thousandeyes/sdk/internet/insights/InternetInsightsOutagesApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.internet.insights.model.ApiApplicationOutageDetails;
 import com.thousandeyes.sdk.internet.insights.model.ApiNetworkOutageDetails;
 import com.thousandeyes.sdk.internet.insights.model.ApiOutageFilter;

--- a/snapshots/src/main/java/com/thousandeyes/sdk/snapshots/TestSnapshotsApi.java
+++ b/snapshots/src/main/java/com/thousandeyes/sdk/snapshots/TestSnapshotsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.snapshots.model.Error;
 import com.thousandeyes.sdk.snapshots.model.SnapshotRequest;
 import com.thousandeyes.sdk.snapshots.model.SnapshotResponse;

--- a/streaming/src/main/java/com/thousandeyes/sdk/streaming/StreamingApi.java
+++ b/streaming/src/main/java/com/thousandeyes/sdk/streaming/StreamingApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.streaming.model.ApiError;
 import com.thousandeyes.sdk.streaming.model.ApiErrorIntegrationLimits;
 import com.thousandeyes.sdk.streaming.model.BadRequestError;
@@ -253,7 +253,7 @@ public class StreamingApi {
 
     var requestBuilder = getStreamsRequestBuilder(aid, type);
 
-    return apiClient.sendForList(requestBuilder.build(), GetStreamResponse.class);
+    return apiClient.send(requestBuilder.build(), TypeUtils.parameterize(List.class, GetStreamResponse.class));
   }
 
   private void getStreamsValidateRequest() throws ApiException {

--- a/tags/src/main/java/com/thousandeyes/sdk/tags/TagAssignmentApi.java
+++ b/tags/src/main/java/com/thousandeyes/sdk/tags/TagAssignmentApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tags.model.ApiError;
 import com.thousandeyes.sdk.tags.model.BulkTagAssignment;
 import com.thousandeyes.sdk.tags.model.BulkTagAssignments;

--- a/tags/src/main/java/com/thousandeyes/sdk/tags/TagsApi.java
+++ b/tags/src/main/java/com/thousandeyes/sdk/tags/TagsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tags.model.ApiError;
 import com.thousandeyes.sdk.tags.model.BulkTagResponse;
 import com.thousandeyes.sdk.tags.model.Error;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/ApiTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/ApiTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.ApiDetailTestResults;
 import com.thousandeyes.sdk.tests.results.model.ApiTestResults;
 import com.thousandeyes.sdk.tests.results.model.Error;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnsServerTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnsServerTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.DnsServerTestResults;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnsTraceTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnsTraceTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.DnsTraceTestResults;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnssecTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/DnssecTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.DnssecTestResults;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/NetworkBgpTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/NetworkBgpTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.BgpTestResults;
 import com.thousandeyes.sdk.tests.results.model.BgpTestRouteInformationResults;
 import com.thousandeyes.sdk.tests.results.model.Error;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/NetworkTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/NetworkTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import com.thousandeyes.sdk.tests.results.model.NetworkTestResults;
 import java.time.OffsetDateTime;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/VoiceRtpServerTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/VoiceRtpServerTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;
 import com.thousandeyes.sdk.tests.results.model.RtpStreamTestResults;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/VoiceSipServerTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/VoiceSipServerTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;
 import com.thousandeyes.sdk.tests.results.model.SipServerTestResults;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebFtpServerTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebFtpServerTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import com.thousandeyes.sdk.tests.results.model.FtpServerTestResults;
 import java.time.OffsetDateTime;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebHttpServerTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebHttpServerTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import com.thousandeyes.sdk.tests.results.model.Expand;
 import com.thousandeyes.sdk.tests.results.model.HttpTestResults;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebPageLoadTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebPageLoadTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;
 import com.thousandeyes.sdk.tests.results.model.PageLoadDetailTestResults;

--- a/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebTransactionsTestResultsApi.java
+++ b/test-results/src/main/java/com/thousandeyes/sdk/tests/results/WebTransactionsTestResultsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.results.model.Error;
 import java.time.OffsetDateTime;
 import com.thousandeyes.sdk.tests.results.model.UnauthorizedError;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/AgentToAgentTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/AgentToAgentTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.AgentToAgentTestRequest;
 import com.thousandeyes.sdk.tests.model.AgentToAgentTestResponse;
 import com.thousandeyes.sdk.tests.model.AgentToAgentTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/AgentToServerTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/AgentToServerTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.AgentToServerTestRequest;
 import com.thousandeyes.sdk.tests.model.AgentToServerTestResponse;
 import com.thousandeyes.sdk.tests.model.AgentToServerTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/ApiTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/ApiTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.ApiTestRequest;
 import com.thousandeyes.sdk.tests.model.ApiTestResponse;
 import com.thousandeyes.sdk.tests.model.ApiTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/BgpTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/BgpTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.BgpTestRequest;
 import com.thousandeyes.sdk.tests.model.BgpTestResponse;
 import com.thousandeyes.sdk.tests.model.BgpTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/DnsServerTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/DnsServerTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.DnsServerTestRequest;
 import com.thousandeyes.sdk.tests.model.DnsServerTestResponse;
 import com.thousandeyes.sdk.tests.model.DnsServerTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/DnsTraceTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/DnsTraceTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.DnsTraceTestRequest;
 import com.thousandeyes.sdk.tests.model.DnsTraceTestResponse;
 import com.thousandeyes.sdk.tests.model.DnsTraceTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/DnssecTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/DnssecTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.DnsSecTestRequest;
 import com.thousandeyes.sdk.tests.model.DnsSecTestResponse;
 import com.thousandeyes.sdk.tests.model.DnsSecTests;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/FtpServerTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/FtpServerTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import com.thousandeyes.sdk.tests.model.FtpServerTestRequest;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/HttpServerTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/HttpServerTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import com.thousandeyes.sdk.tests.model.HttpServerTestRequest;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/PageLoadTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/PageLoadTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import com.thousandeyes.sdk.tests.model.PageLoadTestRequest;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/PathVisualizationInterfaceGroupsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/PathVisualizationInterfaceGroupsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.InterfaceGroup;
 import com.thousandeyes.sdk.tests.model.InterfaceGroups;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/SipServerTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/SipServerTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import com.thousandeyes.sdk.tests.model.SipServerTestRequest;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/TestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/TestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.Tests;
 import com.thousandeyes.sdk.tests.model.UnauthorizedError;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/VoiceTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/VoiceTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import java.net.URI;

--- a/tests/src/main/java/com/thousandeyes/sdk/tests/WebTransactionTestsApi.java
+++ b/tests/src/main/java/com/thousandeyes/sdk/tests/WebTransactionTestsApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.tests.model.Error;
 import com.thousandeyes.sdk.tests.model.ExpandTestOptions;
 import java.net.URI;

--- a/usage/src/main/java/com/thousandeyes/sdk/usage/QuotasApi.java
+++ b/usage/src/main/java/com/thousandeyes/sdk/usage/QuotasApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.usage.model.Error;
 import com.thousandeyes.sdk.usage.model.OrganizationsQuotasAssign;
 import com.thousandeyes.sdk.usage.model.OrganizationsQuotasUnassign;

--- a/usage/src/main/java/com/thousandeyes/sdk/usage/UsageApi.java
+++ b/usage/src/main/java/com/thousandeyes/sdk/usage/UsageApi.java
@@ -20,7 +20,7 @@ import com.thousandeyes.sdk.client.ApiResponse;
 import com.thousandeyes.sdk.client.ApiRequest;
 import com.thousandeyes.sdk.utils.Config;
 import org.apache.commons.lang3.tuple.Pair;
-
+import org.apache.commons.lang3.reflect.TypeUtils;
 import com.thousandeyes.sdk.usage.model.EnterpriseAgentsUsage;
 import com.thousandeyes.sdk.usage.model.Error;
 import com.thousandeyes.sdk.usage.model.ExpandUsageOptions;


### PR DESCRIPTION
Using a `Type` argument, rather then a separate `sendForList` method makes the client more flexible and reduces duplication within client implementations

Also changing headers type from `Map<String, List<String>>` to `Map<String, Collection<String>>` for better compatibility