### PR TITLE
Fix: Resolve workflow vulnerabilities

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,15 +7,21 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   validate-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_version: ${{ steps.validate.outputs.release_version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: validate
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
@@ -33,14 +39,15 @@ jobs:
   publish-release:
     needs: validate-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v4
         with:
-          # We need to use a PAT from an Admin user here, so that we can bypass the branch protection rules when pushing to main
-          token: ${{ secrets.SDK_ACTION_TOKEN }}
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -53,13 +60,19 @@ jobs:
           sed -i "s|^\(version=\).*|\1${RELEASE_VERSION}|" gradle.properties
 
       - name: Add tag and push to the repository
+        env:
+          SDK_ACTION_TOKEN: ${{ secrets.SDK_ACTION_TOKEN }}
         run: |
           git config user.name "API Team"
           git config user.email "api-team@thousandeyes.com"
 
+          # PAT is scoped to this step only so it is not available during publish/signing.
+          git remote set-url origin "https://x-access-token:${SDK_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add .
           git commit -m "[GitHub Bot] Released ${RELEASE_VERSION} SDK"
           git push origin
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git config --global --unset-all credential.helper || true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+# Manual release only. GitHub allows workflow_dispatch only for users with write
+# access to this repository. Maven Central publish is further gated by the "release" environment.
 name: Release
 on:
   workflow_dispatch:
@@ -5,25 +7,43 @@ on:
       releaseVersion:
         description: 'The target version you want to update and release (semver, e.g. 1.2.3)'
         required: true
+        type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  publish-release:
+  validate-release:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+    outputs:
+      release_version: ${{ steps.validate.outputs.release_version }}
     steps:
-      - name: Validate release version
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: validate
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
         run: |
-          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid release version: $RELEASE_VERSION (expected semver, e.g. 1.2.3)"
+          if ! printf '%s' "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'; then
+            echo "Invalid releaseVersion: must match X.Y.Z or X.Y.ZrcN (e.g. 2.26.0 or 2.0.0rc1)" >&2
             exit 1
           fi
+          if git rev-parse "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${RELEASE_VERSION} already exists" >&2
+            exit 1
+          fi
+          echo "release_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout latest code
-        uses: actions/checkout@v4
+  publish-release:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -31,13 +51,37 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Upgrade the version number in the gradle.properties
+      - name: Publish artifact
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+        run: |
+          echo "Publishing version: ${RELEASE_VERSION}"
+          gradle -Pversion="${RELEASE_VERSION}" publishMavenPublicationToMavenCentralRepository --parallel
+
+  commit-and-release:
+    needs: [validate-release, publish-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # PAT from an admin user so we can bypass branch protection when pushing to main
+          token: ${{ secrets.SDK_ACTION_TOKEN }}
+
+      - name: Update version and push to repository
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
         run: |
           echo "Releasing the target version: ${RELEASE_VERSION}"
           sed -i "s|^\(version=\).*|\1${RELEASE_VERSION}|" gradle.properties
 
-      - name: Add tag and push to the repository
-        run: |
           git config user.name "API Team"
           git config user.email "api-team@thousandeyes.com"
 
@@ -45,17 +89,10 @@ jobs:
           git commit -m "[GitHub Bot] Released ${RELEASE_VERSION} SDK"
           git push origin
 
-          git tag "${RELEASE_VERSION}"
-          git push origin "${RELEASE_VERSION}"
-
-      - name: Publish artifact
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
-        run: |
-          echo "New version: ${RELEASE_VERSION}"
-          echo "Github username: ${GITHUB_ACTOR}"
-          gradle -Pversion="${RELEASE_VERSION}" publishMavenPublicationToMavenCentralRepository --parallel
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.validate-release.outputs.release_version }}
+          prerelease: false
+          draft: false
+          generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Add tag and push to the repository
         env:
+          # We need to use a PAT from an Admin user here, so that we can bypass the branch protection rules when pushing to main
           SDK_ACTION_TOKEN: ${{ secrets.SDK_ACTION_TOKEN }}
         run: |
           git config user.name "API Team"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
         run: |
-          if ! printf '%s' "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'; then
-            echo "Invalid releaseVersion: must match X.Y.Z or X.Y.ZrcN (e.g. 2.26.0 or 2.0.0rc1)" >&2
+          if ! printf '%s' "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$'; then
+            echo "Invalid releaseVersion: must match X.Y.Z or X.Y.Z-RCN (e.g. 2.26.0 or 2.0.0-RC1)" >&2
             exit 1
           fi
           if git rev-parse "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.validate-release.outputs.release_version }}
+          tag_name: ${{ env.RELEASE_VERSION }}
           prerelease: false
           draft: false
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,11 @@
-# Manual release only. GitHub allows workflow_dispatch only for users with write
-# access to this repository. Maven Central publish is further gated by the "release" environment.
 name: Release
 on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: 'The target version you want to update and release (semver, e.g. 1.2.3)'
+        description: 'The target version you want to update and release'
         required: true
         type: string
-
-permissions:
-  contents: read
 
 jobs:
   validate-release:
@@ -38,12 +33,14 @@ jobs:
   publish-release:
     needs: validate-release
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    environment:
-      name: release
+    env:
+      RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout latest code
+        uses: actions/checkout@v4
+        with:
+          # We need to use a PAT from an Admin user here, so that we can bypass the branch protection rules when pushing to main
+          token: ${{ secrets.SDK_ACTION_TOKEN }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -51,41 +48,16 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Publish artifact
-        env:
-          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+      - name: Upgrade the version number in the gradle.properties
         run: |
-          echo "Publishing version: ${RELEASE_VERSION}"
-          gradle -Pversion="${RELEASE_VERSION}" publishMavenPublicationToMavenCentralRepository --parallel
-
-  commit-and-release:
-    needs: [validate-release, publish-release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          # PAT from an admin user so we can bypass branch protection when pushing to main
-          token: ${{ secrets.SDK_ACTION_TOKEN }}
-
-      - name: Update version and push to repository
-        env:
-          RELEASE_VERSION: ${{ needs.validate-release.outputs.release_version }}
-        run: |
-          echo "Releasing the target version: ${RELEASE_VERSION}"
           sed -i "s|^\(version=\).*|\1${RELEASE_VERSION}|" gradle.properties
 
+      - name: Add tag and push to the repository
+        run: |
           git config user.name "API Team"
           git config user.email "api-team@thousandeyes.com"
 
-          git add gradle.properties
+          git add .
           git commit -m "[GitHub Bot] Released ${RELEASE_VERSION} SDK"
           git push origin
 
@@ -96,3 +68,15 @@ jobs:
           prerelease: false
           draft: false
           generate_release_notes: true
+
+      - name: Publish artifact
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY_BASE64 }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+        run: |
+          echo "New version: ${RELEASE_VERSION}"
+          echo "Github username: ${GITHUB_ACTOR}"
+          gradle -Pversion="${RELEASE_VERSION}" publishMavenPublicationToMavenCentralRepository --parallel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,19 +3,27 @@ on:
   workflow_dispatch:
     inputs:
       releaseVersion:
-        description: 'The target version you want to update and release'
+        description: 'The target version you want to update and release (semver, e.g. 1.2.3)'
         required: true
-        type: string
+
+permissions:
+  contents: write
 
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
     steps:
+      - name: Validate release version
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release version: $RELEASE_VERSION (expected semver, e.g. 1.2.3)"
+            exit 1
+          fi
+
       - name: Checkout latest code
         uses: actions/checkout@v4
-        with:
-          # We need to use a PAT from an Admin user here, so that we can bypass the branch protection rules when pushing to main
-          token: ${{ secrets.SDK_ACTION_TOKEN }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -25,24 +33,20 @@ jobs:
 
       - name: Upgrade the version number in the gradle.properties
         run: |
-          sed -i "s|^\(version=\).*|\1${{ inputs.releaseVersion }}|" gradle.properties
+          echo "Releasing the target version: ${RELEASE_VERSION}"
+          sed -i "s|^\(version=\).*|\1${RELEASE_VERSION}|" gradle.properties
 
       - name: Add tag and push to the repository
         run: |
           git config user.name "API Team"
           git config user.email "api-team@thousandeyes.com"
 
-          git add .
-          git commit -m "[GitHub Bot] Released ${{ inputs.releaseVersion }} SDK"
+          git add gradle.properties
+          git commit -m "[GitHub Bot] Released ${RELEASE_VERSION} SDK"
           git push origin
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.releaseVersion }}
-          prerelease: false
-          draft: false
-          generate_release_notes: true
+          git tag "${RELEASE_VERSION}"
+          git push origin "${RELEASE_VERSION}"
 
       - name: Publish artifact
         env:
@@ -52,6 +56,6 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
         run: |
-          echo "New version: ${{ inputs.releaseVersion }}"
+          echo "New version: ${RELEASE_VERSION}"
           echo "Github username: ${GITHUB_ACTOR}"
-          gradle -Pversion=${{ inputs.releaseVersion }} publishMavenPublicationToMavenCentralRepository --parallel
+          gradle -Pversion="${RELEASE_VERSION}" publishMavenPublicationToMavenCentralRepository --parallel


### PR DESCRIPTION
Validate `releaseVersion` (semver / `rc` format) and reject duplicate tags before publish