### PR TITLE
Feat: replace SDK_ACTION_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,16 +59,23 @@ jobs:
         run: |
           sed -i "s|^\(version=\).*|\1${RELEASE_VERSION}|" gradle.properties
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.API_TEAM_AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.API_TEAM_AUTOMATION_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Add tag and push to the repository
         env:
-          # We need to use a PAT from an Admin user here, so that we can bypass the branch protection rules when pushing to main
-          SDK_ACTION_TOKEN: ${{ secrets.SDK_ACTION_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "API Team"
           git config user.email "api-team@thousandeyes.com"
 
-          # PAT is scoped to this step only so it is not available during publish/signing.
-          git remote set-url origin "https://x-access-token:${SDK_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # App token is scoped to this step only so it is not available during publish/signing.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add .
           git commit -m "[GitHub Bot] Released ${RELEASE_VERSION} SDK"
           git push origin


### PR DESCRIPTION
## Summary
- Replace `SDK_ACTION_TOKEN` with a GitHub App token from `actions/create-github-app-token@v3` in `release.yaml`
- Use the app token only for the release commit/push step so it is not available during Maven publish/signing

## Test plan
- [ ] Confirm `API_TEAM_AUTOMATION_CLIENT_ID` var and `API_TEAM_AUTOMATION_PRIVATE_KEY` secret are configured in this repo
- [ ] Confirm the GitHub App is installed on this repo and configured as a branch protection bypass actor if required
- [ ] Run the release workflow in a test scenario and verify push to main succeeds


Made with [Cursor](https://cursor.com)